### PR TITLE
Revert "fix(node): fixes compatibilty issue with prev version"

### DIFF
--- a/nodes/SqliteNode/SqliteNode.node.ts
+++ b/nodes/SqliteNode/SqliteNode.node.ts
@@ -54,7 +54,7 @@ async function exec(db: BetterSqlite3Database, query: string): Promise<any> {
 export class SqliteNode implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'SQLite Node',
-		name: 'SqliteNode',
+		name: 'sqliteNode',
 		icon: 'file:sqlite-icon.svg',
 		group: ['transform'],
 		version: 1,


### PR DESCRIPTION
Reverts DangerBlack/n8n-node-sqlite3#11

Due to

```
npm run lint

> n8n-nodes-sqlite3@0.3.1 lint
> eslint nodes package.json


/home/danger/Documents/progetti/n8n-sqlite3-node/nodes/SqliteNode/SqliteNode.node.ts
  57:3  error  Change to camel case [autofixable]  n8n-nodes-base/node-class-description-name-miscased

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
```

Sadly as I suppose this pr fix an issue with breaking compatibility with old nodes but it's part of n8n standards (was introduced later after the node was published the first time).
I suggest for whoever like me have old nodes to copy them in a text editor rename the node and past them again in the workflows.